### PR TITLE
<feature proposal> ignore foreign key when import command

### DIFF
--- a/cmd/carpenter/command/before.go
+++ b/cmd/carpenter/command/before.go
@@ -14,11 +14,16 @@ var db *sql.DB
 var schema string
 var verbose bool
 var dryrun bool
+var maxIdleConns int
+var maxOpenConns int
 
 func Before(c *cli.Context) error {
 	verbose = c.GlobalBool("verbose")
 	dryrun = c.GlobalBool("dry-run")
 	schema = c.GlobalString("schema")
+	maxIdleConns = c.GlobalInt("max-idle-conns")
+	maxOpenConns = c.GlobalInt("max-open-conns")
+
 	if len(schema) <= 0 {
 		return fmt.Errorf("err: Specify required `--schema' option")
 	}
@@ -31,8 +36,8 @@ func Before(c *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("err: db.Open is failed for reason %v", err)
 	}
-	db.SetMaxIdleConns(1)
-	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(maxIdleConns)
+	db.SetMaxOpenConns(maxOpenConns)
 	db.SetConnMaxLifetime(time.Minute)
 	return nil
 }

--- a/cmd/carpenter/command/before.go
+++ b/cmd/carpenter/command/before.go
@@ -31,8 +31,8 @@ func Before(c *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("err: db.Open is failed for reason %v", err)
 	}
-	db.SetMaxIdleConns(0)
-	db.SetMaxOpenConns(8)
+	db.SetMaxIdleConns(1)
+	db.SetMaxOpenConns(1)
 	db.SetConnMaxLifetime(time.Minute)
 	return nil
 }

--- a/cmd/carpenter/command/seed.go
+++ b/cmd/carpenter/command/seed.go
@@ -27,8 +27,6 @@ func CmdSeed(c *cli.Context) {
 		queries = append([]string{mysql.ForeignKeyCheck(false)}, queries...)
 
 		defer func() {
-
-			// TODO (tacogips) defer ResetForeginKeyCheckSettingSomehow()
 			if err := execute([]string{mysql.ForeignKeyCheck(true)}); err != nil {
 				panic(fmt.Errorf("err: execute failed for reason %s", err))
 			}

--- a/cmd/carpenter/command/seed.go
+++ b/cmd/carpenter/command/seed.go
@@ -21,6 +21,20 @@ func CmdSeed(c *cli.Context) {
 	if len(errs) > 0 {
 		panic(fmt.Errorf("err: makeSeedQueries failed for reason\n%s", strings.Join(getErrorMessages(errs), "\n")))
 	}
+
+	ignoreForeignKey := c.Bool("ignore-foreign-key")
+	if ignoreForeignKey {
+		queries = append([]string{mysql.ForeignKeyCheck(false)}, queries...)
+
+		defer func() {
+
+			// TODO (tacogips) defer ResetForeginKeyCheckSettingSomehow()
+			if err := execute([]string{mysql.ForeignKeyCheck(true)}); err != nil {
+				panic(fmt.Errorf("err: execute failed for reason %s", err))
+			}
+		}()
+	}
+
 	if err := execute(queries); err != nil {
 		panic(fmt.Errorf("err: execute failed for reason %s", err))
 	}

--- a/cmd/carpenter/commands.go
+++ b/cmd/carpenter/commands.go
@@ -79,6 +79,11 @@ var Commands = []cli.Command{
 				Usage:  "path to CSV file directory (required)",
 				Hidden: false,
 			},
+			cli.BoolFlag{
+				Name:   "ignore-foreign-key, i",
+				Usage:  "ignore foreign key check",
+				Hidden: false,
+			},
 		},
 	},
 	{

--- a/cmd/carpenter/commands.go
+++ b/cmd/carpenter/commands.go
@@ -29,6 +29,18 @@ var GlobalFlags = []cli.Flag{
 		Usage:  "data source name like '[username[:password]@][tcp[(address:port)]]' (required)",
 		Hidden: false,
 	},
+	cli.IntFlag{
+		Name:   "max-idle-conns, mi",
+		Usage:  "max idel database connection setting",
+		Hidden: false,
+		Value:  0,
+	},
+	cli.IntFlag{
+		Name:   "max-open-conns, mo",
+		Usage:  "max open database connection setting",
+		Hidden: false,
+		Value:  8,
+	},
 }
 
 var Commands = []cli.Command{

--- a/dialect/mysql/system.go
+++ b/dialect/mysql/system.go
@@ -1,0 +1,12 @@
+package mysql
+
+import "fmt"
+
+//ForeignKeyCheck returns  `"SET FOREIGN_KEY_CHECKS = %s"`
+func ForeignKeyCheck(turnOn bool) string {
+	v := "0"
+	if turnOn {
+		v = "1"
+	}
+	return fmt.Sprintf("SET foreign_key_checks = %s", v)
+}


### PR DESCRIPTION
Thanks to maintain good migration tool. I about to use this tool in production.

when I execute import command,  I got  ` failed for reason Error 1452: Cannot add or update a child row: a foreign key constraint fails ... ` error.
To avoid this, I made reference implement to execute `SET foreign_key_checks = 0` before insertion.
I hope you will consider this or is there any other walk around ?

---

I set MaxOpenConns to 1 because `SET foreign_key_checks = 0` not work if another connection(that has default setting) in connection pool used for insertion.
we need to find another way if it leads to  performance issue.