### PR TITLE
Add Print Semicolon when verbose flag is set

### DIFF
--- a/cmd/carpenter/command/util.go
+++ b/cmd/carpenter/command/util.go
@@ -23,7 +23,7 @@ func execute(queries []string) error {
 			}
 		}
 		if verbose {
-			fmt.Println(query)
+			fmt.Println(query + ";")
 		}
 	}
 	return nil


### PR DESCRIPTION
If the verbose and dryrun flags are set as is, I would like to use the output result.

For example, if you want to change the local DB of a remote DB that is considerably restricted to the same access privilege state, an authorized person issues a query without accessing "carpenter".
In this case, the output result is output to a file and redirected to the DBM command, but since there is no semicolon in the output result, it is necessary to add a semicolon every time.

Therefore, I added a semicolon to the output of the query.